### PR TITLE
Newer Debian doesn't have legacy apt sources file

### DIFF
--- a/packages/apt_install_packages.sh
+++ b/packages/apt_install_packages.sh
@@ -69,7 +69,7 @@ if is_CI; then
     opts="$opts -q"
     echo
     echo "/etc/apt/sources.list:"
-    cat /etc/apt/sources.list
+    cat /etc/apt/sources.list ||:
     echo
     for x in /etc/apt/sources.list.d/*; do
         [ -f "$x" ] || continue


### PR DESCRIPTION
Trivial fix to get build to pass on Debian 12+.