### PR TITLE
Workaround bug in Cirrus /tmp filesystem

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,8 +23,8 @@ container:
   image: ubuntu:18.04
 
 task:
-  # doesn't work properly
-  #skip: "!changesInclude('**/*.md')"
+  env:
+    TMPDIR: /var/tmp
   script:
     - setup/ci_bootstrap.sh
     - make init


### PR DESCRIPTION
No clue why. But Cirrus CI mounts up /tmp as a separate filesystem and this causes `apt-get update` to break thusly:

```
Err:1 http://archive.ubuntu.com/ubuntu bionic InRelease
  Couldn't create temporary file /tmp/apt.conf.8lxPno for passing config to apt-key
```

This patch is a workaround.