### PR TITLE
Scrut uses Ubuntu 14 by default which doesn't support jq -e

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,7 +14,7 @@
 #
 
 build:
-  image: ubuntu:16.04
+  image: default-bionic
   nodes:
     auto:
       commands:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,11 +14,10 @@
 #
 
 build:
+  image: ubuntu:16.04
   nodes:
     auto:
       commands:
-        # not working
-        #- checkout-code ~/build
         - repo="${SCRUTINIZER_PROJECT#*/}"; git clone "https://github.com/$repo" build
         - cd ~/build
         - pwd

--- a/packages/apt_install_packages.sh
+++ b/packages/apt_install_packages.sh
@@ -23,7 +23,6 @@
 set -eu
 [ -n "${DEBUG:-}" ] && set -x
 srcdir="$(cd "$(dirname "$0")" && pwd)"
-set -x
 
 # shellcheck disable=SC1090,SC1091
 . "$srcdir/lib/utils-bourne.sh"
@@ -50,6 +49,7 @@ done
 
 echo "Installing Deb Packages"
 
+export NEEDRESTART_MODE=a
 export DEBIAN_FRONTEND=noninteractive
 
 #apt="apt"
@@ -112,10 +112,6 @@ fi
 
 # uniq
 packages="$(echo "$packages" | tr ' ' ' \n' | sort -u | tr '\n' ' ')"
-
-export NEEDRESTART_MODE=a
-export DEBIAN_FRONTEND=noninteractive
-export DEBIAN_PRIORITY=critical
 
 # requires fuser which might not already be installed, catch-22 situation if wanting to use this for everything including bootstraps
 #"$srcdir/apt_wait.sh"

--- a/packages/apt_install_packages.sh
+++ b/packages/apt_install_packages.sh
@@ -112,6 +112,7 @@ fi
 # uniq
 packages="$(echo "$packages" | tr ' ' ' \n' | sort -u | tr '\n' ' ')"
 
+export NEEDRESTART_MODE=a
 export DEBIAN_FRONTEND=noninteractive
 
 # requires fuser which might not already be installed, catch-22 situation if wanting to use this for everything including bootstraps

--- a/packages/apt_install_packages.sh
+++ b/packages/apt_install_packages.sh
@@ -112,6 +112,8 @@ fi
 # uniq
 packages="$(echo "$packages" | tr ' ' ' \n' | sort -u | tr '\n' ' ')"
 
+export DEBIAN_FRONTEND=noninteractive
+
 # requires fuser which might not already be installed, catch-22 situation if wanting to use this for everything including bootstraps
 #"$srcdir/apt_wait.sh"
 

--- a/packages/apt_install_packages.sh
+++ b/packages/apt_install_packages.sh
@@ -23,6 +23,7 @@
 set -eu
 [ -n "${DEBUG:-}" ] && set -x
 srcdir="$(cd "$(dirname "$0")" && pwd)"
+set -x
 
 # shellcheck disable=SC1090,SC1091
 . "$srcdir/lib/utils-bourne.sh"
@@ -114,6 +115,7 @@ packages="$(echo "$packages" | tr ' ' ' \n' | sort -u | tr '\n' ' ')"
 
 export NEEDRESTART_MODE=a
 export DEBIAN_FRONTEND=noninteractive
+export DEBIAN_PRIORITY=critical
 
 # requires fuser which might not already be installed, catch-22 situation if wanting to use this for everything including bootstraps
 #"$srcdir/apt_wait.sh"


### PR DESCRIPTION
Testing if this is the right way to use tell Scrutinizer to use a different container.